### PR TITLE
Add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ log = { version = "0.4", optional = true }
 [features]
 default = []
 log = ["dep:log"]
+
+[dev-dependencies]
+libloading = "0.8"
+tracing-subscriber = "0.3"
+simple_logger = "5"
+
+[workspace]
+members = [".", "examples/example-lib"]
+default-members = ["."]

--- a/examples/example-lib/Cargo.toml
+++ b/examples/example-lib/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example-lib"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+tracing-shared = { path = "../.." }
+tracing = "0.1"
+log = { version = "0.4", optional = true }
+
+[features]
+log = ["dep:log", "tracing-shared/log"]

--- a/examples/example-lib/src/lib.rs
+++ b/examples/example-lib/src/lib.rs
@@ -1,0 +1,9 @@
+#[no_mangle]
+pub fn run(logger: tracing_shared::SharedLogger) {
+    tracing_shared::setup_shared_logger(logger);
+
+    println!("dylib println!");
+    tracing::info!("dylib tracing::info!");
+    #[cfg(feature = "log")]
+    log::info!("dylib log::info!");
+}

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,76 @@
+use std::{io::Write, path::PathBuf};
+
+fn main() {
+    // build example-lib
+    let dylib = build_dylib();
+
+    // set tracing logger
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .without_time()
+            .finish(),
+    )
+    .unwrap();
+
+    // set log logger
+    #[cfg(feature = "log")]
+    simple_logger::SimpleLogger::new()
+        .without_timestamps()
+        .init()
+        .unwrap();
+
+    // log in the normal program
+    println!("program println!");
+    tracing::info!("program tracing::info!");
+    #[cfg(feature = "log")]
+    log::info!("program log::info!");
+
+    // log in the dylib, see `example-lib/src/lib.rs`
+    run_dylib(dylib);
+}
+
+fn run_dylib(dylib: PathBuf) {
+    let dylib = unsafe { libloading::Library::new(dylib) }.expect("error loading dylib");
+    let run: fn(tracing_shared::SharedLogger) = unsafe { *dylib.get(b"run").unwrap() };
+
+    run(tracing_shared::build_shared_logger());
+}
+
+fn build_dylib() -> PathBuf {
+    print!("building `example-lib`...");
+    std::io::stdout().flush().unwrap();
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("build")
+        .arg("--manifest-path")
+        .arg("examples/example-lib/Cargo.toml")
+        .arg("--message-format")
+        .arg("json");
+
+    #[cfg(feature = "log")]
+    cmd.arg("--features=log");
+
+    let output = cmd.output().unwrap();
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        eprintln!("{error}");
+        panic!("dylib build failed");
+    }
+
+    let output = String::from_utf8_lossy(&output.stdout);
+
+    for line in output.lines().rev() {
+        if line.starts_with(r#"{"reason":"compiler-artifact""#) {
+            let files_start = r#""filenames":[""#;
+            let i = line.find(files_start).unwrap();
+            let line = &line[i + files_start.len()..];
+            let i = line.find('"').unwrap();
+            let dylib = &line[..i];
+
+            println!(" done");
+
+            return PathBuf::from(dylib);
+        }
+    }
+    panic!("failed to find get dylib output");
+}


### PR DESCRIPTION
Add example that builds and uses a dylib to test the logger sharing.

Use `cargo run --example example --features=log` to run.